### PR TITLE
Minor correctness: the use of skip-chars-backward/forward is not correct

### DIFF
--- a/number.el
+++ b/number.el
@@ -131,7 +131,9 @@
     (goto-char (1- (point))))
   (let ((point (point)))
     (skip-chars-forward "+-")
-    (skip-chars-forward "0-9.")
+    (skip-chars-forward "0-9")
+    (when (looking-at "\.[0-9]")
+      (skip-chars-forward ".0-9"))
     (set-mark (point))
     (goto-char point)))
 

--- a/number.el
+++ b/number.el
@@ -126,12 +126,12 @@
 (defun number/mark ()
   "Mark the number at point."
   (interactive)
-  (when (looking-back "[0-9.]+")
-    (skip-chars-backward "[0-9.]+"))
+  (skip-chars-backward "0-9.")
   (when (looking-back "[+\\-]")
-    (skip-chars-backward "[+\\-]"))
+    (goto-char (1- (point))))
   (let ((point (point)))
-    (skip-chars-forward "[+\\-]?[0-9.]+")
+    (skip-chars-forward "+-")
+    (skip-chars-forward "0-9.")
     (set-mark (point))
     (goto-char point)))
 

--- a/number.el
+++ b/number.el
@@ -147,10 +147,11 @@
 (defun number-transform (f)
   "Transform the number at point in some way."
   (let ((point (point)))
-    (let* ((beg-end (progn (unless (region-active-p)
+    (let* ((beg-end (prog2 (unless (region-active-p)
                              (number/mark))
                            (list (region-beginning)
-                                 (region-end))))
+                                 (region-end))
+                           (deactivate-mark)))
            (string (apply 'buffer-substring-no-properties beg-end)))
       (let ((new (number-format (funcall f (number-read string)))))
         (apply 'delete-region beg-end)
@@ -176,8 +177,10 @@
                            (number-get number :decimal-padding)
                            (number-get number :number))))
     (integral
-     (format (format "%%0.%dd" (number-get number :padding))
-             (number-get number :number)))))
+     (if (= 0 (number-get number :number))
+         "0"
+       (format (format "%%0.%dd" (number-get number :padding))
+               (number-get number :number))))))
 
 (defun number-pad-decimal (left-pad right-pad n)
   "Pad a decimal on the left- and right-hand side of the decimal

--- a/number.el
+++ b/number.el
@@ -132,7 +132,7 @@
   (let ((point (point)))
     (skip-chars-forward "+-")
     (skip-chars-forward "0-9")
-    (when (looking-at "\.[0-9]")
+    (when (looking-at "\\.[0-9]")
       (skip-chars-forward ".0-9"))
     (set-mark (point))
     (goto-char point)))

--- a/number.el
+++ b/number.el
@@ -133,7 +133,8 @@
     (skip-chars-forward "+-")
     (skip-chars-forward "0-9")
     (when (looking-at "\\.[0-9]")
-      (skip-chars-forward ".0-9"))
+      (skip-chars-forward ".")
+      (skip-chars-forward "0-9"))
     (set-mark (point))
     (goto-char point)))
 


### PR DESCRIPTION
This package is awesome. I like it. And I write another function to work with multiple-cursors, sometimes we need to change a lot index numbers at the same time.
But I find a problem, when deal with something like this: `arr[1]`. The `]` will be deleted.
So look into the codes, and find that the use of `skip-chars-backward` and `skip-chars-forward` is not correct. These functions take the paramter of the body inside `[]`, but act as `[...]` in functions like `re-search-backward`. The doc is as follows:
```
STRING is like the inside of a ‘[...]’ in a regular expression except that ‘]’ is never special.
```
So, intead of use `(skip-chars-forward "[0-9]")`, we should omit the `[]`, and just use `(skip-chars-forward "0-9")`, otherwise, the `]` will be treated as the normal char, and get deleted. ^_^